### PR TITLE
added missing return

### DIFF
--- a/routes/pokemons.js
+++ b/routes/pokemons.js
@@ -9,7 +9,7 @@ const pokemonData = require('../pokemon');
 
 module.exports = {
   getAll: (req, res) => {
-    res.json(pokemonData);
+    return res.json(pokemonData);
   },
   getByNumber: (req, res) => {
     let id = req.params.id;


### PR DESCRIPTION
Because node is async by nature, it would've executed any code after res.json. By putting the return statements it ensures that is the end of the function
